### PR TITLE
Make Plot.Arg match what parser delivers

### DIFF
--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -38,9 +38,7 @@ arglist  -> '(' args ')'                         : '$2'.
 args     -> arg                                  : ['$1'].
 args     -> arg ',' args                         : ['$1'|'$3'].
 
-% arg      -> key ':' value                        : {value('$1'), '$3'}.
-% insert the key as the first element of the tuple returned via the value
-arg      -> key ':' value                        : erlang:insert_element(1, '$3', value('$1')).
+arg      -> key ':' value                        : {value('$1'), '$3'}.
 
 array    -> '[' ']'                              : [].
 array    -> '[' list ']'                         : '$2'.

--- a/test/plot_test.exs
+++ b/test/plot_test.exs
@@ -17,7 +17,7 @@ defmodule PlotTest do
 
   test "{user(id: 4)}" do
     assert {:ok,
-      [{:query, nil, [ {:field, "user", nil, [{"id", :number, 4}]} ] }]
+      [{:query, nil, [ {:field, "user", nil, [{"id", {:number, 4}}]} ] }]
     } = Plot.parse("{user(id: 4)}")
   end
 
@@ -30,7 +30,7 @@ defmodule PlotTest do
   test "basic user with field" do
     assert {:ok,
       [{:query, nil,
-        [ {:object, "user", nil, [{"id", :number, 4}], [{:field, "name", nil, []}]} ]
+        [ {:object, "user", nil, [{"id", {:number, 4}}], [{:field, "name", nil, []}]} ]
       }]
     } = read_fixture("user") |> Plot.parse
   end
@@ -51,10 +51,10 @@ defmodule PlotTest do
     assert {:ok,
       [{:query, nil,
         [
-          {:object, "user", nil, [{"id", :number, 4}], [
+          {:object, "user", nil, [{"id", {:number, 4}}], [
             {:field, "id", nil, []},
             {:field, "name", nil, []},
-            {:field, "profilePic", nil, [{"width", :number, 100}, {"height", :number, 50}]}
+            {:field, "profilePic", nil, [{"width", {:number, 100}}, {"height", {:number, 50}}]}
           ]}
         ]
       }]
@@ -66,7 +66,7 @@ defmodule PlotTest do
       [{:query, nil,
         [
           {
-            :object, "user", nil, [{"id", :number, 4}], [
+            :object, "user", nil, [{"id", {:number, 4}}], [
               {:field, "id", nil, []},
               {:field, "firstName", nil, []},
               {:field, "lastName",  nil, []},
@@ -85,7 +85,7 @@ defmodule PlotTest do
   test "user with top level alias" do
     assert {:ok,
       [{:query, nil, [
-        {:object, "user", "phil", [{"id", :number, 4}], [
+        {:object, "user", "phil", [{"id", {:number, 4}}], [
           {:field, "id",   nil, []},
           {:field, "name", nil, []}
         ]}
@@ -97,11 +97,11 @@ defmodule PlotTest do
     assert {:ok,
       [{:query, nil,
         [
-          {:object, "user", nil, [{"id", :number, 4}], [
+          {:object, "user", nil, [{"id", {:number, 4}}], [
             {:field, "id", nil, []},
             {:field, "name", nil, []},
-            {:field, "profilePic", "smallPic", [{"size", :number, 64}]},
-            {:field, "profilePic", "bigPic", [{"size", :number, 1024}]}
+            {:field, "profilePic", "smallPic", [{"size", {:number, 64}}]},
+            {:field, "profilePic", "bigPic", [{"size", {:number, 1024}}]}
           ]}
         ]
       }]
@@ -178,7 +178,7 @@ defmodule PlotTest do
     assert {:ok,
       [{:query, nil,
         [{:object, "user", nil,
-          [{"things", :array, [{:number, 4}, {:string, "phil"}, {:variable, "whatever"}]}],
+          [{"things", {:array, [{:number, 4}, {:string, "phil"}, {:variable, "whatever"}]}}],
           [{:field, "id", nil, []}]
           }
         ]


### PR DESCRIPTION
Hey!

We're currently playing around with plot during a hackathon at XING and really like what you've done so far with the library. However we've run into a roadblock with arguments which this pull request attempts to fix.

The current code of `Plot.Arg` doesn't match what get's delivered by the generated parser. It gives you a bad match when trying to assign the parsed structure to [`Plot.Arg`](https://github.com/peburrows/plot/blob/master/lib/plot/arg.ex#L13). The code in the tests for `Plot.Arg` indicates that you want the parser to deliver a keyword list / list of tagged tuples. 

We thought parsing out atoms out of user supplied code doesn't seem like a good idea, because afaik the atom table is not garbage collected (Please correct me if I'm wrong here).  That's why we changed the code back to parse out the arguments as binaries/strings.

This fixes the bad match and makes the whole `Plug.parse_and_generate` work end-2-end for that case.

What do you think?
- Björn
