### PR TITLE
Fix parser error when aliasing a simple field

### DIFF
--- a/src/graphql_parser.yrl
+++ b/src/graphql_parser.yrl
@@ -26,6 +26,7 @@ object   -> '.' '.' '.' on key '{' objects '}'   : #fragment{type=value('$5'), o
 
 % with aliases
 object   -> key ':' value                        : #field{name=value('$3'), alias=value('$1')}.
+object   -> key ':' key                          : #field{name=value('$3'), alias=value('$1')}.
 object   -> key ':' key arglist                  : #field{name=value('$3'), alias=value('$1'), args='$4'}.
 object   -> key ':' key '{' objects '}'          : #object{name=value('$3'), alias=value('$1'), children='$5'}.
 object   -> key ':' key arglist '{' objects '}'  : #object{name=value('$3'), alias=value('$1'), args='$4', children='$6' }.

--- a/test/fixtures/user-with-field-aliases.gql
+++ b/test/fixtures/user-with-field-aliases.gql
@@ -2,7 +2,7 @@
   user(id: 4) {
     id,
     name,
-    smallPic: profilePic(size: 64),
+    smallPic: profilePic,
     bigPic: profilePic(size: 1024)
   }
 }

--- a/test/plot_test.exs
+++ b/test/plot_test.exs
@@ -100,7 +100,7 @@ defmodule PlotTest do
           {:object, "user", nil, [{"id", {:number, 4}}], [
             {:field, "id", nil, []},
             {:field, "name", nil, []},
-            {:field, "profilePic", "smallPic", [{"size", {:number, 64}}]},
+            {:field, "profilePic", "smallPic", []},
             {:field, "profilePic", "bigPic", [{"size", {:number, 1024}}]}
           ]}
         ]


### PR DESCRIPTION
Hey!

This fixes a parsing error when parsing 

```
{
   user(id: 1) {
     foo: bar,
     baz
   }
}
```

There was a rule missing for aliases on fields.

Cheerio!
